### PR TITLE
[WEB-3920] 입력한 태그 문자열 안나오는 버그 수정

### DIFF
--- a/src/utils/valueParserUtils.ts
+++ b/src/utils/valueParserUtils.ts
@@ -1,6 +1,8 @@
 import Decimal from 'decimal.js';
 import { isNaN, isNumber } from 'lodash';
 
+type MatchEntity = '&amp;' | '&lt;' | '&gt;' | '&quot;' | '&#39;' | '&#x2F;' | '&#x60;' | '&#x3D;';
+
 /**
  * 특정 길이만큼 앞에 특정값을 채움
  */
@@ -87,7 +89,7 @@ export const removeSpaceAndLineBreak = (str: string) => {
   return str.replace(/\[LINEBREAK\]/g, '').replace(/\s+/g, '');
 };
 
-export const decodeHtmlEntities = (str: string) => {
+export const decodeHtmlEntities = (str: string, matchEntities: MatchEntity[] = []) => {
   const entityMap = {
     '&amp;': '&',
     '&lt;': '<',
@@ -105,7 +107,9 @@ export const decodeHtmlEntities = (str: string) => {
   let prevStr = '';
   while (decodedStr !== prevStr) {
     prevStr = decodedStr;
-    decodedStr = decodedStr.replace(/&[#\w]+;/g, (match) => entityMap[match] || match);
+    decodedStr = decodedStr.replace(/&[#\w]+;/g, (match) =>
+      matchEntities.includes(match as MatchEntity) ? entityMap[match] || match : match
+    );
   }
 
   return decodedStr;
@@ -113,7 +117,7 @@ export const decodeHtmlEntities = (str: string) => {
 
 export const convertMarkdownToHtmlStr = (text: string) => {
   // 변환된 문자열을 저장할 변수 초기화
-  let convertStr = decodeHtmlEntities(text);
+  let convertStr = decodeHtmlEntities(text, ['&amp;', '&quot;', '&#39;']);
 
   // WP@ 변환
   convertStr = convertStr.replace(


### PR DESCRIPTION
(main, storybook 브랜치의 경우 입력하지 않으셔도 자동으로 커밋 내역이 입력되니 입력하지 않으셔도 됩니다)

## 📒 요약

입력한 태그 문자열 안나오는 버그 수정

## 🛠️ 작업 내역

- fix: 입력한 태그는 입력한 대로 문자열 형식으로 그대로 노출 되도록 수정


## 🖊️ 리뷰 받고 싶은 사항들

- 중점적으로 리뷰를 받고 싶은 부분이 어떤 부분인가요? (없다면 그냥 두셔도 됩니다)